### PR TITLE
Adding the className property to the context variable inside `before`-Callback

### DIFF
--- a/src/aspect.js
+++ b/src/aspect.js
@@ -93,6 +93,7 @@
         joinPointContext = {
           isStopped: false,
           methodName: methodName,
+					className: target.constructor.name,
           stop: function() {
             this.isStopped = true;
           }

--- a/test/test.before.js
+++ b/test/test.before.js
@@ -205,4 +205,61 @@ module("jsAspect.before");
     deepEqual(calledMethodNames, [], "Original methods have been stopped");
     deepEqual(calledAdviceNames, ["beforeAdvice3", "beforeAdvice3"], "Remaining advices have not been called");
   });
+
+	test("jsAspect.inject 'before' advice, last `context` argument contains target/class name", function ()
+	{
+		var obj = {
+			method1: function ()
+			{
+				return "method1value";
+			},
+			method2: function ()
+			{
+				return "method2value";
+			}
+		};
+
+
+		function Account(){
+			this.amount = 1000;
+		}
+
+		Account.prototype.withDraw = function (nAmount)
+		{
+			if (this.amount < nAmount)
+			{
+				return false;
+			}
+			this.amount -= nAmount;
+			return true;
+		};
+
+
+		var calledClassNames = [];
+
+		jsAspect.inject(obj, jsAspect.pointcuts.methods, jsAspect.advices.before,
+			function ()
+			{
+				var context = arguments[arguments.length - 1];
+
+				calledClassNames.push(context.className);
+			}
+		);
+
+		//An example for a own data type.
+		jsAspect.inject(Account, jsAspect.pointcuts.prototypeMethods, jsAspect.advices.before,
+			function ()
+			{
+				var context = arguments[arguments.length - 1];
+
+				calledClassNames.push(context.className);
+			}
+		);
+		var acc1 = new Account();
+
+		equal(obj.method1(), "method1value", "method1 executed");
+		equal(obj.method2(), "method2value", "method2 executed");
+		equal(acc1.withDraw(500), true, "withDrawn 500 dollars");
+		deepEqual(calledClassNames, ["Object", "Object", "Account"], "Method name is available in context");
+	});
 })();


### PR DESCRIPTION
Adding the className property to the context variable inside `before`-Callback.

This is required for better logging purposes within object-orientied applications.

Test included into test.before.js with an additional custom type `Account`.
