### PR TITLE
Enable by setting to advice inherited methods.

### DIFF
--- a/test/test.after.js
+++ b/test/test.after.js
@@ -4,9 +4,8 @@ module("jsAspect.after");
     
     test("jsAspect.inject: 'after' advice, 'prototypeMethods' pointcut", function() {
         function Object() {
-        };
-        
-        Object.prototype.method1 = function() {
+        }
+      Object.prototype.method1 = function() {
             return "method1value";
         };
         
@@ -14,7 +13,7 @@ module("jsAspect.after");
             return "method2value";
         };
         
-        jsAspect.inject(Object, jsAspect.pointcuts.prototypeMethods, jsAspect.joinPoints.after,
+        jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.AFTER,
             function afterCallback() {
                 var args = [].slice.call(arguments, 0);
 
@@ -32,11 +31,10 @@ module("jsAspect.after");
 
     test("jsAspect.inject: 'after' advice, 'prototypeMethods' pointcut, object contains fields other than functions, they are left intact", function() {
         function Object() {
-        };
-
-        Object.prototype.field1 = "field1value";
+        }
+      Object.prototype.field1 = "field1value";
         
-        jsAspect.inject(Object, jsAspect.pointcuts.prototypeMethods, jsAspect.joinPoints.after,
+        jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.AFTER,
             function afterCallback() {
             }
         );
@@ -50,9 +48,8 @@ module("jsAspect.after");
         var adviceNames = ["advice1", "advice2", "advice3", "advice4", "advice5"];
         
         function Object() {
-        };
-        
-        Object.prototype.method1 = function() {
+        }
+      Object.prototype.method1 = function() {
             return "method1value";
         };
         
@@ -62,7 +59,7 @@ module("jsAspect.after");
         
         adviceNames.forEach(function(adviceName) {
             (function (adviceName) {
-                jsAspect.inject(Object, jsAspect.pointcuts.prototypeMethods, jsAspect.joinPoints.after,
+                jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.AFTER,
                     function() {
                         var args = [].slice.call(arguments, 0);
 
@@ -86,14 +83,14 @@ module("jsAspect.after");
 
     test("jsAspect.inject: 'after' advice is executed after method invocation", function() {
         function Object() {
-        };
+        }
         
         Object.prototype.method1 = function() {
             this.accumulated && this.accumulated.splice(0, this.accumulated.length);
             return "method1value";
         };
         
-        jsAspect.inject(Object, jsAspect.pointcuts.prototypeMethods, jsAspect.joinPoints.after,
+        jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.AFTER,
             function() {
                 var args = [].slice.call(arguments, 0);
             
@@ -110,9 +107,8 @@ module("jsAspect.after");
     
     test("jsAspect.inject 'after' advice, 'methods' pointcut", function() {
         function Object() {
-        };
-        
-        //Should not be enhanced with an aspect
+        }
+      //Should not be enhanced with an aspect
         Object.prototype.method1 = function() {
             return "method1value";
         };
@@ -124,7 +120,7 @@ module("jsAspect.after");
             return "method2value";
         };
 
-        jsAspect.inject(obj, jsAspect.pointcuts.methods, jsAspect.joinPoints.after,
+        jsAspect.inject(obj, jsAspect.POINTCUT.METHODS, jsAspect.JOIN_POINT.AFTER,
             function() {
                 var args = [].slice.call(arguments, 0);
             

--- a/test/test.afterreturning.js
+++ b/test/test.afterreturning.js
@@ -4,13 +4,12 @@ module("jsAspect.afterReturning");
     
     test("jsAspect.inject: 'afterReturning' advice, 'prototypeMethods' pointcut", function() {
         function Object() {
-        };
-        
-        Object.prototype.wrapValue = function(value) {
+        }
+      Object.prototype.wrapValue = function(value) {
             return {value: value};
         };
         
-        jsAspect.inject(Object, jsAspect.pointcuts.prototypeMethods, jsAspect.joinPoints.afterReturning,
+        jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.AFTER_RETURNING,
             function afterReturningCallback(retValue) {
                 retValue.value = retValue.value + 1;
                 return retValue;
@@ -24,20 +23,19 @@ module("jsAspect.afterReturning");
 
     test("jsAspect.inject: several 'afterReturning' aspects", function() {
         function Object() {
-        };
-        
-        Object.prototype.identity = function(value) {
+        }
+      Object.prototype.identity = function(value) {
             return value;
         };
         
         ["aspect1", "aspect2", "aspect3"].forEach(function (aspectName) {
-            jsAspect.inject(Object, jsAspect.pointcuts.prototypeMethods, jsAspect.joinPoints.afterReturning,
+            jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.AFTER_RETURNING,
                 function afterReturningCallback(retValue) {
                     return retValue + "_" + aspectName;
                 }
             );
         });
         
-        equal(new Object().identity("value"), "value_aspect3_aspect2_aspect1", "'afterReturning' several aspects applied in the reverse order");     
+        equal(new Object().identity("value"), "value_aspect3_aspect2_aspect1", "'afterReturning' several aspects applied in the reverse order");
     });    
 })();

--- a/test/test.afterthrowing.js
+++ b/test/test.afterthrowing.js
@@ -4,9 +4,8 @@ module("jsAspect.afterThrowing");
     
     test("jsAspect.inject: 'afterThrowing' advice, 'prototypeMethods' pointcut", function() {
         function Object() {
-        };
-        
-        Object.prototype.method1 = function() {
+        }
+      Object.prototype.method1 = function() {
             throw new Error("method1exception");
         };
         
@@ -14,7 +13,7 @@ module("jsAspect.afterThrowing");
             throw new Error("method2exception");
         };
         
-        jsAspect.inject(Object, jsAspect.pointcuts.prototypeMethods, jsAspect.joinPoints.afterThrowing,
+        jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.AFTER_THROWING,
             function afterThrowingCallback(exception) {
                 this.thrownExceptions = this.thrownExceptions || [];
                 this.thrownExceptions.push(exception.message);
@@ -38,9 +37,8 @@ module("jsAspect.afterThrowing");
     
     test("jsAspect.inject: 'afterThrowing' several aspects", function() {
         function Object() {
-        };
-        
-        Object.prototype.method1 = function() {
+        }
+      Object.prototype.method1 = function() {
             throw new Error("method1exception");
         };
         
@@ -48,12 +46,12 @@ module("jsAspect.afterThrowing");
             throw new Error("method2exception");
         };
         
-        jsAspect.inject(Object, jsAspect.pointcuts.prototypeMethods, jsAspect.joinPoints.afterThrowing,
+        jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.AFTER_THROWING,
             function afterThrowingCallback(exception) {
                 exception.message = exception.message + "_aspect1"
             }
         );
-        jsAspect.inject(Object, jsAspect.pointcuts.prototypeMethods, jsAspect.joinPoints.afterThrowing,
+        jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.AFTER_THROWING,
             function afterThrowingCallback(exception) {
                 exception.message = exception.message + "_aspect2"
             }
@@ -75,13 +73,13 @@ module("jsAspect.afterThrowing");
 
     test("jsAspect.inject: 'afterThrowing' advice throws an exception", function() {
         function Object() {
-        };
+        }
         
         Object.prototype.method = function() {
             throw new Error("method1exception");
         };
         
-        jsAspect.inject(Object, jsAspect.pointcuts.prototypeMethods, jsAspect.joinPoints.afterThrowing,
+        jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.AFTER_THROWING,
             function afterThrowingCallback(exception) {
                 throw new Error("callbackexception");            
             }
@@ -94,6 +92,6 @@ module("jsAspect.afterThrowing");
             ok(false, "Exception should have been thrown at this point");
         } catch (e) {
             equal(e.message, "callbackexception", "Exception from advice");
-        };        
+        }
     });
 })();

--- a/test/test.around.js
+++ b/test/test.around.js
@@ -4,9 +4,8 @@ module("jsAspect.around");
     
     test("jsAspect.inject: 'around' advice, 'prototypeMethods' pointcut", function() {
         function Object() {
-        };
-        
-        Object.prototype.identity = function(x) {
+        }
+      Object.prototype.identity = function(x) {
             return x;
         };
         
@@ -14,7 +13,7 @@ module("jsAspect.around");
             return x - 1;
         };
         
-        jsAspect.inject(Object, jsAspect.pointcuts.prototypeMethods, jsAspect.joinPoints.around,
+        jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.AROUND,
             function aroundCallback(func, x) {
                 return 2 * func(x);
             }
@@ -28,9 +27,8 @@ module("jsAspect.around");
 
     test("jsAspect.inject: 'around' advice, 'prototypeMethods' pointcut, multiple arguments in the method", function() {
         function Object() {
-        };
-        
-        Object.prototype.sum = function() {
+        }
+      Object.prototype.sum = function() {
             var args = [].slice.call(arguments, 0);
             
             return args.reduce(function(accumulated, current){
@@ -38,7 +36,7 @@ module("jsAspect.around");
             });
         };
 
-        jsAspect.inject(Object, jsAspect.pointcuts.prototypeMethods, jsAspect.joinPoints.around,
+        jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.AROUND,
             function aroundCallback(func) {
                 var args = [].slice.call(arguments, 1),
                     sum = func.apply(this, args);
@@ -57,9 +55,8 @@ module("jsAspect.around");
         var obj = new Object();
 
         function Object() {
-        };
-        
-        Object.prototype.identity = function(x) {
+        }
+      Object.prototype.identity = function(x) {
             equal(obj, this, "'this' is correct in 'identity'");
             return x;
         };
@@ -69,19 +66,19 @@ module("jsAspect.around");
             return x - 1;
         };
         
-        jsAspect.inject(Object, jsAspect.pointcuts.prototypeMethods, jsAspect.joinPoints.around,
+        jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.AROUND,
             function aroundCallback(func, x) {
                 equal(obj, this, "'this' is correct in advice 1");
                 return 2 * func(x);
             }
         );
-        jsAspect.inject(Object, jsAspect.pointcuts.prototypeMethods, jsAspect.joinPoints.around,
+        jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.AROUND,
             function aroundCallback(func, x) {
                 equal(obj, this, "'this' is correct in advice 2");
                 return 3 * func(x);
             }
         );
-        jsAspect.inject(Object, jsAspect.pointcuts.prototypeMethods, jsAspect.joinPoints.around,
+        jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.AROUND,
             function aroundCallback(func, x) {
                 equal(obj, this, "'this' is correct in advice 3");
                 return 4 * func(x);
@@ -94,9 +91,8 @@ module("jsAspect.around");
     
     test("jsAspect.inject: 'around' advice, 'self' pointcut", function() {
         function Object() {
-        };
-        
-        Object.prototype.identity = function(x) {
+        }
+      Object.prototype.identity = function(x) {
             return x;
         };
 
@@ -106,7 +102,7 @@ module("jsAspect.around");
             return 2 * x;
         };
         
-        jsAspect.inject(obj, jsAspect.pointcuts.methods, jsAspect.joinPoints.around,
+        jsAspect.inject(obj, jsAspect.POINTCUT.METHODS, jsAspect.JOIN_POINT.AROUND,
             function aroundCallback(func, x) {
                 return func(x) - 1;
             }

--- a/test/test.before.js
+++ b/test/test.before.js
@@ -4,8 +4,7 @@ module("jsAspect.before");
 
   test("jsAspect.inject: 'before' advice, 'prototypeMethods' pointcut", function() {
     function Object() {
-    };
-
+    }
     Object.prototype.method1 = function() {
       return "method1value";
     };
@@ -14,7 +13,7 @@ module("jsAspect.before");
       return "method2value";
     };
 
-    jsAspect.inject(Object, jsAspect.pointcuts.prototypeMethods, jsAspect.joinPoints.before,
+    jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.BEFORE,
       function beforeCallback() {
         var args = [].slice.call(arguments, 1);
 
@@ -32,11 +31,10 @@ module("jsAspect.before");
 
   test("jsAspect.inject: 'before' advice, 'prototypeMethods' pointcut, object contains fields other than functions, they are left intact", function() {
     function Object() {
-    };
-
+    }
     Object.prototype.field1 = "field1value";
 
-    jsAspect.inject(Object, jsAspect.pointcuts.prototypeMethods, jsAspect.joinPoints.before,
+    jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.BEFORE,
       function beforeCallback() {
       }
     );
@@ -50,8 +48,7 @@ module("jsAspect.before");
     var adviceNames = ["advice1", "advice2", "advice3", "advice4", "advice5"];
 
     function Object() {
-    };
-
+    }
     Object.prototype.method1 = function() {
       return "method1value";
     };
@@ -62,7 +59,7 @@ module("jsAspect.before");
 
     adviceNames.forEach(function(adviceName) {
       (function (adviceName) {
-        jsAspect.inject(Object, jsAspect.pointcuts.prototypeMethods, jsAspect.joinPoints.before,
+        jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.BEFORE,
           function() {
             var args = [].slice.call(arguments, 1);
 
@@ -86,14 +83,13 @@ module("jsAspect.before");
 
   test("jsAspect.inject: 'before' advice is executed before method invocation", function() {
     function Object() {
-    };
-
+    }
     Object.prototype.method1 = function() {
       this.accumulated && this.accumulated.splice(0, this.accumulated.length);
       return "method1value";
     };
 
-    jsAspect.inject(Object, jsAspect.pointcuts.prototypeMethods, jsAspect.joinPoints.before,
+    jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.BEFORE,
       function() {
         var args = [].slice.call(arguments, 1);
 
@@ -110,8 +106,7 @@ module("jsAspect.before");
 
   test("jsAspect.inject 'before' advice, 'methods' pointcut", function() {
     function Object() {
-    };
-
+    }
     //Should not be enhanced with an aspect
     Object.prototype.method1 = function() {
       return "method1value";
@@ -124,7 +119,7 @@ module("jsAspect.before");
       return "method2value";
     };
 
-    jsAspect.inject(obj, jsAspect.pointcuts.methods, jsAspect.joinPoints.before,
+    jsAspect.inject(obj, jsAspect.POINTCUT.METHODS, jsAspect.JOIN_POINT.BEFORE,
       function() {
         var args = [].slice.call(arguments, 1);
 
@@ -149,7 +144,7 @@ module("jsAspect.before");
     };
     var calledMethodNames = [];
 
-    jsAspect.inject(obj, jsAspect.pointcuts.methods, jsAspect.joinPoints.before,
+    jsAspect.inject(obj, jsAspect.POINTCUT.METHODS, jsAspect.JOIN_POINT.BEFORE,
       function(context) {
         calledMethodNames.push(context.methodName);
       }
@@ -174,18 +169,18 @@ module("jsAspect.before");
       }
     };
 
-    jsAspect.inject(obj, jsAspect.pointcuts.methods, jsAspect.joinPoints.before,
+    jsAspect.inject(obj, jsAspect.POINTCUT.METHODS, jsAspect.JOIN_POINT.BEFORE,
       function() {
         calledAdviceNames.push("beforeAdvice1");
       }
     );
 
-    jsAspect.inject(obj, jsAspect.pointcuts.methods, jsAspect.joinPoints.before,
+    jsAspect.inject(obj, jsAspect.POINTCUT.METHODS, jsAspect.JOIN_POINT.BEFORE,
       function() {
         calledAdviceNames.push("beforeAdvice2");
       }
     );
-    jsAspect.inject(obj, jsAspect.pointcuts.methods, jsAspect.joinPoints.before,
+    jsAspect.inject(obj, jsAspect.POINTCUT.METHODS, jsAspect.JOIN_POINT.BEFORE,
       function(context) {
         context.stop();
         calledAdviceNames.push("beforeAdvice3");
@@ -222,12 +217,12 @@ module("jsAspect.before");
 
     var calledClassNames = [];
 
-    jsAspect.inject(obj, jsAspect.pointcuts.methods, jsAspect.joinPoints.before, function(context) {
+    jsAspect.inject(obj, jsAspect.POINTCUT.METHODS, jsAspect.JOIN_POINT.BEFORE, function(context) {
       calledClassNames.push(context.targetConstructor.name);
     });
 
     //An example for a own data type.
-    jsAspect.inject(Account, jsAspect.pointcuts.prototypeMethods, jsAspect.joinPoints.before, function(context) {
+    jsAspect.inject(Account, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.BEFORE, function(context) {
       calledClassNames.push(context.targetConstructor.name);
     });
 

--- a/test/test.introduce.js
+++ b/test/test.introduce.js
@@ -1,23 +1,21 @@
 module("jsAspect.introduce");
 
 (function() {
-    
+
     test("jsAspect.introduce: 'methods' pointcut", function() {
         function Object() {
-            this.field1 = "field1value"; 
-            this.field2 = "field2value"; 
-        };
-        
-        Object.prototype.method1 = function () {
+            this.field1 = "field1value";
+        }
+      Object.prototype.method1 = function () {
             return "valuefrommethod1";
         };
-        
+
         equal(Object.field3, undefined, "Object.field3");
         equal(Object.prototype.field3, undefined, "Object.prototype.field3");
         equal(Object.staticmethod1, undefined, "Object.staticmethod1");
         equal(Object.prototype.staticmethod1, undefined, "Object.prototype.staticmethod1");
 
-        jsAspect.introduce(Object, jsAspect.pointcuts.methods, {
+        jsAspect.introduce(Object, jsAspect.POINTCUT.METHODS, {
             field3: "field3value",
             staticmethod1: function () {
                 return "valuefromstaticmethod1";
@@ -32,28 +30,26 @@ module("jsAspect.introduce");
 
     test("jsAspect.introduce: 'prototype' pointcut", function() {
         function Object() {
-            this.field1 = "field1value"; 
-            this.field2 = "field2value"; 
-        };
-        
-        Object.prototype.method1 = function () {
+            this.field1 = "field1value";
+        }
+      Object.prototype.method1 = function () {
             return "valuefrommethod1";
         };
-        
+
         equal(Object.field3, undefined, "Object.field3");
         equal(Object.prototype.field3, undefined, "Object.prototype.field3");
         equal(Object.method2, undefined, "Object.method2");
         equal(Object.prototype.method2, undefined, "Object.prototype.method2");
-        
-        jsAspect.introduce(Object, jsAspect.pointcuts.prototypeMethods, {
+
+        jsAspect.introduce(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, {
             field3: "field3value",
             method2: function () {
                 return "valuefrommethod2";
             }
         });
-        
+
         var obj = new Object();
-        
+
         equal(Object.field3, undefined, "Object.field3");
         equal(Object.prototype.field3, "field3value", "Object.prototype.field3");
         equal(Object.method2, undefined, "Object.method2");

--- a/test/test.pointcuts.method.js
+++ b/test/test.pointcuts.method.js
@@ -1,4 +1,4 @@
-module("jsAspect.pointcuts.method");
+module("jsAspect.POINTCUT.method");
 
 (function() {
 
@@ -25,7 +25,7 @@ module("jsAspect.pointcuts.method");
       return "method3value";
     };
 
-    jsAspect.inject(global, jsAspect.pointcuts.method, jsAspect.joinPoints.before,
+    jsAspect.inject(global, jsAspect.POINTCUT.METHOD, jsAspect.JOIN_POINT.BEFORE,
       function() {
         var args = [].slice.call(arguments, 1);
 
@@ -48,7 +48,7 @@ module("jsAspect.pointcuts.method");
 
     global.field1 = "field1value";
 
-    jsAspect.inject(global, jsAspect.pointcuts.method, jsAspect.joinPoints.before,
+    jsAspect.inject(global, jsAspect.POINTCUT.METHOD, jsAspect.JOIN_POINT.BEFORE,
       function() {
         return "valuefromaspect";
       }, "field1");


### PR DESCRIPTION
**Enable to advice inherited methods by setting**:
A possible szenario is, that i want to advice all inherited methods. 
This is now possible by setting a flag: 

``` javascript
var LoggerAspect = new jsAspect.Aspect(beforeAdvice, afterAdvice);
LoggerAspect.settings.adviceInheritedMethods = true;
LoggerAspect.applyTo(Child);
```

Maybe move the setting into the `applyTo` method: 

``` javascript
LoggerAspect.applyTo(Child, {
 adviceInheritedMethods: true
});
```

But maybe you want to set this setting at the aspect itself and apply it to multiple Objects/Constructors.
_See the test_: "jsAspect.applyAdvice: Apply aspect with inheritance" in _test.multiple.advice_. (Maybe move the test into other/new file.)

**Rename all constant values to uppercase**: 
This is required, to make clear, that these are readonly constant values. 
It's a best practice in most languages.
IDEs or browsers can then autocomplete the input of the user when typing `jsAspect.` and the jsHint will stop crying, because it doesnt know the variable `pointcut.>>method<<`.

**Few fixes and changes, to make jsLint happy**

**Changes to method interfaces**:
- `inject`: Did take 5 parameters, while the last parameter `methodName` just got ignored, if the point_cut wasn't `METHOD`. 
  To apply settings, this last parameter can be a string or an object. 
  If it's an object -> it's a setting otherwise, it's the actual method name.  
  Since the `POINT_CUT.METHOD` doens't have any settings yet, we won't pass one more parameter.
