### PR TITLE
Arguments in context

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ jsAspect
 
 Aspect-oriented framework for JavaScript
 
-[toc]
+
 
 ## Terminology
 
@@ -13,18 +13,22 @@ Aspect-oriented framework for JavaScript
 - `Intercept`: The technical overwritting of the method to attach the join points.
 
 ## API 
+`jsAspect.JOIN_POINT`: Contains all available join points.
 
-Existing ***join points*** yet:
+>Existing ***join points*** yet:
 - `before`: Will be executed before the adviced method
 - `afterThrowing`: Will be executed after the adviced method thrown an error.
 - `afterReturning`: Will be executed after the adviced method returned a value
 - `after`: Will be executed after the adviced method
 - `around`: Will be executed instead of the adviced method, passed the function and the arguments to execute the function by yourself.
 
-Existing ***pointcuts*** yet: 
+`jsAspect.POINTCUT`: Contains all available pointcuts.
+
+>Existing ***pointcuts*** yet: 
 - `prototype_methods`: *Default* Intercepts all prototype methods (even inherited)
 - `methods`: To advice object methods, instead of prototype methods
 - `prototype_own_methods`: Like `prototype_methods` without inherited methods.
+
 
 ## Usage 
 ### Define Advice

--- a/README.md
+++ b/README.md
@@ -2,3 +2,136 @@ jsAspect
 ========
 
 Aspect-oriented framework for JavaScript
+
+[toc]
+
+## Terminology
+
+- `Advice`: Additional behaviour added into a join point of a method.
+- `Join Point`: Places within the method invokation process, that can be join with additional Behaviourr.
+- `Pointcuts`: Works like a filter, to specify which methods need to be intercepted
+- `Intercept`: The technical overwritting of the method to attach the join points.
+
+## API 
+
+Existing ***join points*** yet:
+- `before`: Will be executed before the adviced method
+- `afterThrowing`: Will be executed after the adviced method thrown an error.
+- `afterReturning`: Will be executed after the adviced method returned a value
+- `after`: Will be executed after the adviced method
+- `around`: Will be executed instead of the adviced method, passed the function and the arguments to execute the function by yourself.
+
+Existing ***pointcuts*** yet: 
+- `prototype_methods`: *Default* Intercepts all prototype methods (even inherited)
+- `methods`: To advice object methods, instead of prototype methods
+- `prototype_own_methods`: Like `prototype_methods` without inherited methods.
+
+## Usage 
+### Define Advice
+At first, we have to define an `Advice`:
+``` javascript
+var afterAdvice =  new jsAspect.Advice.After(function() {
+   console.log("joinPoint", "after");
+});
+var beforeAdvice = new jsAspect.Advice.Before(function() {
+   console.log("joinPoint", "before");
+});
+```
+In this example we defined two advices, an `before` and a `after` advice. 
+### Define Aspect
+Up next we need to define a `Aspect`.
+``` javascript
+var aspect = new jsAspect.Aspect([
+     beforeAdvice,  afterAdvice
+]);
+```
+The `Aspect` takes the `Advice`'s as parameter. 
+### Apply Aspect to an object
+Now we can apply this `Aspect` to any constructor or object.
+
+``` javascript
+var obj = new Object();
+obj.method1 = function(){
+    return "doing Something";
+});
+
+aspect.applyTo(obj);
+
+obj.method1();
+```
+This method execution will log:
+`joinPoint after`
+`joinPoint before`
+### Apply Aspect to an constructor/class
+Once the `Aspect` is defined, we can apply it so several objects or constructors.
+
+Let's take a look at constructors:
+
+``` javascript
+function Target(){}
+
+Target.prototype.method1 = function() {
+  return "method1value";
+};
+
+aspect.applyTo(Target); 
+
+var target = new Target();
+target.method1(); 
+
+//logs: `joinPoint after`
+//logs: `joinPoint before`
+``` 
+> Hint: Place methods on the prototype of a constructor. If you place them directly into the constructor, the whole constructor will be copied, since we can't override these methods.
+
+__DON'T to it like this:__
+``` javascript
+function Target(){
+    this.method1 = function() {
+        return "method1value";
+    };
+}
+
+aspect.applyTo(Target); 
+
+var target = new Target();
+target.method1();
+``` 
+#### Advices to inherited methods
+Works by default. To turn of, re-set the pointcut to `PROTOTYPE.OWN_METHODS`.
+
+If your want to advice methods that are embedded like this in a constructor, place apply to `Aspect` to the object of this constructor.
+### Apply Aspect to objects
+To apply an `Aspect` to an object, you have to change the *pointcuts* at the advices, to advice the objects methods, instead of it's prototype methods. 
+``` javascript
+//Define behaviour of the afterAdvice
+var afterAdviceBehaviour = function() {
+   console.log("joinPoint", "after");
+};
+var afterAdvice =  new jsAspect.Advice.After(afterAdviceBehaviour, jsAspect.POINTCUT.METHODS); //set the pointcut
+
+//Define behaviour of the beforeAdvice
+var beforeAdviceBehaviour = function() {
+   console.log("joinPoint", "before");
+};
+var beforeAdvice = new jsAspect.Advice.Before(beforeAdviceBehaviour, jsAspect.POINTCUT.METHODS); //set the pointcut 
+
+//create the aspect
+var aspect = new jsAspect.Aspect([beforeAdvice, afterAdvice]);
+
+function Target(){
+    this.method1 = function() {
+        return "method1value";
+    };
+}
+var target = new Target();
+//Apply aspect on the object instead of the prototype
+aspect.applyTo(target); 
+
+target.method1();
+
+//logs: `joinPoint after`
+//logs: `joinPoint before`
+``` 
+
+

--- a/src/aspect.js
+++ b/src/aspect.js
@@ -153,8 +153,8 @@
       var self = this,
         method = target[methodName],
         args = toArray(arguments),
-        returnValue = undefined,
-        executionContext = new ExecutionContext(target, methodName);
+        returnValue = undefined;
+      var  executionContext = new ExecutionContext(target, methodName, args);
 
       applyBeforeAdvices(self, method, args, executionContext);
       if (executionContext.isStopped) return;
@@ -178,7 +178,7 @@
    * @param context
    * @param method
    * @param args
-   * @param executionContext
+   * @param {ExecutionContext} executionContext
    * @method applyBeforeAdvices
    */
   function applyBeforeAdvices(context, method, args, executionContext) {
@@ -266,9 +266,12 @@
    * @param methodName
    * @constructor
    */
-  function ExecutionContext(target, methodName) {
+  function ExecutionContext(target, methodName, args) {
     this.target = target;
-    this.methodName = methodName;
+    this.method ={
+      "name":methodName,
+      "arguments": args
+    };
     this.targetConstructor = target.constructor;
     this.isStopped = false;
   }
@@ -421,7 +424,7 @@
     AfterReturning: AfterReturning,
     AfterThrowing: AfterThrowing,
     Around: Around
-  },
+  };
   jsAspect.Aspect = Aspect;
   host.jsAspect = jsAspect;
 })(window);

--- a/test/test.aspect.js
+++ b/test/test.aspect.js
@@ -267,4 +267,50 @@ module("jsAspect.Aspect");
       {joinPoint: "after"}
     ], "Advices applied only for own methods");
   });
+
+  test("jsAspect.applyAdvice: Arguments in the context", function ()
+  {
+    function Class()
+    {
+    }
+
+    Class.prototype.method1= function(param1)
+    {
+      return param1 + "-method1"
+    };
+
+
+    function beforeAdvice(context)
+    {
+      calledMethods.push({method: context.method.name, joinPoint: "before", args: context.method.arguments});
+    }
+
+    function afterAdvice()
+    {
+      console.log(arguments);
+      calledMethods.push({joinPoint: "after"});
+    }
+
+    /*
+     * PROTOTYPE_METHODS pointcut
+     */
+    var calledMethods = [];
+
+    new jsAspect.Aspect(
+      new jsAspect.Advice.Before(beforeAdvice),
+      new jsAspect.Advice.After(afterAdvice)
+    ).applyTo(Class);
+
+    var child = new Class();
+
+    equal(child.method1("test"), "test-method1", "Child method1");
+    console.log(calledMethods);
+
+    deepEqual(calledMethods, [
+      {method: "method1", joinPoint: "before", args: ["test"] },
+      {joinPoint: "after"},
+    ], "Advices applied for both the inherited and own methods");
+
+  });
+
 })();

--- a/test/test.aspect.js
+++ b/test/test.aspect.js
@@ -16,7 +16,7 @@ module("jsAspect.Aspect");
     var called = [];
 
     var aspect = new jsAspect.Aspect([new jsAspect.Advice.Before(function (context) {
-      called.push({method: context.methodName, constructor: context.targetConstructor.name});
+      called.push({method: context.method.name, constructor: context.targetConstructor.name});
     })]);
 
     aspect.applyTo(Target);
@@ -47,7 +47,7 @@ module("jsAspect.Aspect");
     var aspect = new jsAspect.Aspect([
       new jsAspect.Advice.Before(function(context) {
         called.push({
-          method: context.methodName,
+          method: context.method.name,
           constructor: context.targetConstructor.name, 
           joinPoint: "before"
         });
@@ -96,7 +96,7 @@ module("jsAspect.Aspect");
     var aspect = new jsAspect.Aspect([
       new jsAspect.Advice.Before(function(context) {
         called.push({
-          method: context.methodName,
+          method: context.method.name,
           constructor: context.targetConstructor.name,
           joinPoint: "before"
         });
@@ -184,7 +184,7 @@ module("jsAspect.Aspect");
 
     aspect.applyTo(obj);
 
-    equal(obj.method(), "methodvalue", "method is called successfully");
+    equal(obj.method("test"), "methodvalue", "method is called successfully");
 
     deepEqual(called, ["advice3", "advice2", "advice1"], "Advices were all applied");
   });
@@ -218,7 +218,7 @@ module("jsAspect.Aspect");
     };
 
     function beforeAdvice(context) {
-      calledMethods.push({method: context.methodName, joinPoint: "before"});
+      calledMethods.push({method: context.method.name, joinPoint: "before"});
     }
 
     function afterAdvice() {

--- a/test/test.before.js
+++ b/test/test.before.js
@@ -146,7 +146,7 @@ module("jsAspect.before");
 
     jsAspect.inject(obj, jsAspect.POINTCUT.METHODS, jsAspect.JOIN_POINT.BEFORE,
       function(context) {
-        calledMethodNames.push(context.methodName);
+        calledMethodNames.push(context.method.name);
       }
     );
 


### PR DESCRIPTION
Because i need this feature for today's work, i implemented it. 

The `ExecutionContext` now has an object `method` with properties `name` and `arguments` to have access to the arguments in every Advice with an context.
