### PR TITLE
Added ExecutionContext to afterReturning and afterThrowing Callbacks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ target.method1();
 //logs: `joinPoint before`
 ``` 
 ### The `context` parameter
-The `context` parameter is currently passed to the `before` advices (in the next versions it will be passed to the other types of advices). It provides information about the adviced method itself and the object/constructor the aspect was applied to. Also it contains API to control the execution of the method to which the advice was applied. This is useful, for example, if you're building a logger aspect.
+The `context` parameter is passed to all advices. It provides information about the adviced method itself and the object/constructor the aspect was applied to. Also it contains API to control the execution of the method to which the advice was applied. This is useful, for example, if you're building a logger aspect.
 
 Usage:
 

--- a/test/test.afterreturning.js
+++ b/test/test.afterreturning.js
@@ -10,7 +10,7 @@ module("jsAspect.afterReturning");
         };
         
         jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.AFTER_RETURNING,
-            function afterReturningCallback(retValue) {
+            function afterReturningCallback(context, retValue) {
                 retValue.value = retValue.value + 1;
                 return retValue;
             }
@@ -31,12 +31,36 @@ module("jsAspect.afterReturning");
         
         ["aspect1", "aspect2", "aspect3"].forEach(function (aspectName) {
             jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.AFTER_RETURNING,
-                function afterReturningCallback(retValue) {
+                function afterReturningCallback(context, retValue) {
                     return retValue + "_" + aspectName;
                 }
             );
         });
         
         equal(new Object().identity("value"), "value_aspect3_aspect2_aspect1", "'afterReturning' several aspects applied in the reverse order");
-    });    
+    });
+    test("jsAspect.inject: 'afterReturning' has context", function ()
+    {
+      function Object()
+      {
+      }
+
+      Object.prototype.identity = function (value)
+      {
+        return value;
+      };
+
+        jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.AFTER_RETURNING,
+          function afterReturningCallback(context, retValue)
+          {
+            equal(context.method.name, "identity", "method name is passed to 'context' properly");
+            deepEqual(context.method.arguments, ["test"], "method arguments are passed to 'context' properly");
+            deepEqual(retValue, "test", "return value still passed.");
+          }
+        );
+
+      var obj1 = new Object();
+      obj1.identity("test");
+
+    });
 })();

--- a/test/test.afterthrowing.js
+++ b/test/test.afterthrowing.js
@@ -14,7 +14,7 @@ module("jsAspect.afterThrowing");
         };
         
         jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.AFTER_THROWING,
-            function afterThrowingCallback(exception) {
+            function afterThrowingCallback(context, exception) {
                 this.thrownExceptions = this.thrownExceptions || [];
                 this.thrownExceptions.push(exception.message);
             }
@@ -48,12 +48,12 @@ module("jsAspect.afterThrowing");
         };
         
         jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.AFTER_THROWING,
-            function afterThrowingCallback(exception) {
+            function afterThrowingCallback(context, exception) {
                 exception.message = exception.message + "_aspect1"
             }
         );
         jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.AFTER_THROWING,
-            function afterThrowingCallback(exception) {
+            function afterThrowingCallback(context, exception) {
                 exception.message = exception.message + "_aspect2"
             }
         );
@@ -81,7 +81,7 @@ module("jsAspect.afterThrowing");
         };
         
         jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.AFTER_THROWING,
-            function afterThrowingCallback(exception) {
+            function afterThrowingCallback(context, exception) {
                 throw new Error("callbackexception");
             }
         );
@@ -95,4 +95,37 @@ module("jsAspect.afterThrowing");
             equal(e.message, "callbackexception", "Exception from advice");
         }
     });
+
+  test("jsAspect.inject: 'afterThrowing' advice has context", function ()
+  {
+    function Object()
+    {
+    }
+
+    Object.prototype.method = function ()
+    {
+      throw new Error("method1exception");
+    };
+
+    jsAspect.inject(Object, jsAspect.POINTCUT.PROTOTYPE_METHODS, jsAspect.JOIN_POINT.AFTER_THROWING,
+      function afterThrowingCallback(context, exception)
+      {
+        equal(context.method.name, "method", "method name is passed to 'context' properly");
+        deepEqual(context.method.arguments, [], "method arguments are passed to 'context' properly");
+        throw new Error("callbackexception");
+      }
+    );
+
+    var obj = new Object();
+
+    try
+    {
+      obj.method();
+      ok(false, "Exception should have been thrown at this point");
+    }
+    catch (e)
+    {
+      equal(e.message, "callbackexception", "Exception from advice");
+    }
+  });
 })();


### PR DESCRIPTION
To make the advice callback interface more consistent, i added the execution context as first parameter to afterReturning and afterThrowing callbacks.

Now every advice passed the context first. 
